### PR TITLE
Feature multi redis

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var redis = require('redis');
 var debug = require('debug')('obcache');
@@ -7,48 +7,68 @@ var redisStore = {
 
   init: function(options) {
 
-    var client ;
-    var prefix;
+    var writeClient, readClient, prefix;
     var keylen = 0;
     var maxAge = (options && options.maxAge) || 60000;
-    var port = options.redis.port;
-    var host = options.redis.host;
-    var ropts = {};
+
+    var writeConfig = options.redis;
+
+    // readConfig is completely optional and will be useful when we've master slave configuration.
+    // All writes can go to master and reads can be moved to slave
+    var readConfig  = options.readRedis;
+
+    var ropts       = {};
+    var readRopts   = {};
+
 
     function setKeylen(err,size) {
       keylen = size;
     }
 
-
     if (!options || isNaN(Number(options.id)) ) {
       throw new Error('Specify an integer cacheid for persistence across reboots, not ' + options.id);
     }
 
-    if (options.redis.twemproxy) {
+    if (writeConfig.twemproxy) {
       ropts.no_ready_check = true;
-      debug('twemproxy compat mode. stats on keys will not be available.');
-
+      debug('twemproxy compat mode for writeConfig. multi-get etc wouldn\'t be available.');
     }
-    client = redis.createClient(port, host, ropts);
-
-    client.on('error', function(err) {
+    writeClient = redis.createClient(writeConfig.port, writeConfig.host, ropts);
+    writeClient.on('error', function(err) {
       debug('redis error ' + err);
     });
+    if (!writeConfig.twemproxy) {
+      writeClient.select(options.id);
+      writeClient.dbsize(setKeylen);
+    }
 
-    if (!options.redis.twemproxy) {
-      client.select(options.id);
-      client.dbsize(setKeylen);
-    } 
+
+    readClient = writeClient;
+
+    if (readConfig) {
+      if (readConfig.twemproxy) {
+        readRopts.no_ready_check = true;
+        debug('twemproxy compat mode for readConfig. stats on keys will not be available.');
+      }
+      readClient = redis.createClient(readConfig.port, readConfig.host, readRopts);
+      readClient.on('error', function(err) {
+        debug('redis error ' + err);
+      });
+
+      if (!readConfig.twemproxy) {
+        readClient.select(options.id);
+        readClient.dbsize(setKeylen);
+      }
+    }
+
 
     prefix = 'obc:' + options.id + ':' ;
 
     var rcache = {
       maxAge : maxAge,
-      client : client,
       get : function(key, cb) {
         key = prefix + key;
-        var ttl = this.maxAge/1000;
-        client.get(key, function(err, data){
+        readClient.get(key, function(err, data){
           var result;
           if (err || !data) {
             return cb(err);
@@ -72,7 +92,7 @@ var redisStore = {
           var obj = JSON.stringify(val);
 
           debug('setting key ' + key + ' in redis with ttl ' + ttl);
-          client.setex(key, ttl, obj, function(err){
+          writeClient.setex(key, ttl, obj, function(err){
             if (cb) {
               cb.apply(this, arguments);
             }
@@ -86,14 +106,14 @@ var redisStore = {
 
       expire: function(key,cb) {
         key = prefix + key;
-        client.expire(key,0,cb || function() {});
+        writeClient.expire(key,0,cb || function() {});
       },
 
       reset: function() {
         if (options.redis.twemproxy) {
           throw new Error('Reset is not possible in twemproxy compat mode');
         }
-        client.flushdb();
+        writeClient.flushdb();
       },
 
       size: function() {
@@ -106,7 +126,7 @@ var redisStore = {
         if (options.redis.twemproxy) {
           return -1;
         }
-        client.dbsize(setKeylen);
+        readClient.dbsize(setKeylen);
         return keylen;
       }
     };

--- a/redis.js
+++ b/redis.js
@@ -66,6 +66,7 @@ var redisStore = {
 
     var rcache = {
       maxAge : maxAge,
+      client : writeClient,
       get : function(key, cb) {
         key = prefix + key;
         readClient.get(key, function(err, data){


### PR DESCRIPTION
Often, for use-cases where cache hits are high and the cached value is large, accessing it multiple times (by numerous servers) chokes network bandwidth on redis master. This feature will provide us with support to read from slaves/replicas. We can create multiple slaves/ replicas from master nodes and using slaves for reads will reduce the load and network bandwidth on master node.

In case of multiple slaves, we can use DNS on top of them/ twemproxy to route requests randomly to any of the slaves (considering we just have one master & multiple slaves)